### PR TITLE
Make libnetlink.h friendly to C++ folks

### DIFF
--- a/include/libnetlink.h
+++ b/include/libnetlink.h
@@ -8,6 +8,10 @@
 #include <linux/if_addr.h>
 #include <linux/neighbour.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct rtnl_handle
 {
 	int			fd;
@@ -111,5 +115,8 @@ extern int rtnl_from_file(FILE *, rtnl_filter_t handler,
 #define NDTA_PAYLOAD(n) NLMSG_PAYLOAD(n,sizeof(struct ndtmsg))
 #endif
 
-#endif /* __LIBNETLINK_H__ */
+#ifdef __cplusplus
+}
+#endif
 
+#endif /* __LIBNETLINK_H__ */

--- a/include/libnetlink.h
+++ b/include/libnetlink.h
@@ -1,6 +1,7 @@
 #ifndef __LIBNETLINK_H__
 #define __LIBNETLINK_H__ 1
 
+#include <stdio.h>
 #include <asm/types.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>


### PR DESCRIPTION
Without this, libnetlink.h cannot be used in C++ projects unless every include is surrounded by extern "C"

Additionally, libnetlink.h relies on the FILE data type but it was not including stdio.h (forcing users to include it before including libnetlink.h)
