### PR TITLE
ip: Fix recvmsg with ancillary data

### DIFF
--- a/lib/libnetlink.c
+++ b/lib/libnetlink.c
@@ -1093,15 +1093,15 @@ int rtnl_listen(struct rtnl_handle *rtnl,
 	char   buf[16384];
 	char   cmsgbuf[BUFSIZ];
 
-	if (rtnl->flags & RTNL_HANDLE_F_LISTEN_ALL_NSID) {
-		msg.msg_control = &cmsgbuf;
-		msg.msg_controllen = sizeof(cmsgbuf);
-	}
-
 	iov.iov_base = buf;
 	while (1) {
 		struct rtnl_ctrl_data ctrl;
 		struct cmsghdr *cmsg;
+
+		if (rtnl->flags & RTNL_HANDLE_F_LISTEN_ALL_NSID) {
+			msg.msg_control = &cmsgbuf;
+			msg.msg_controllen = sizeof(cmsgbuf);
+		}
 
 		iov.iov_len = sizeof(buf);
 		status = recvmsg(rtnl->fd, &msg, 0);


### PR DESCRIPTION
A successful call to `recvmsg()` causes `msg.msg_controllen` to contain the length of the received ancillary data. Quoting the manpage for `recvmsg`:
"The field msg_control, which has length msg_controllen, ...; upon return from a successful call it will contain the length of the control message sequence."

Therefore, we must reset this value after each call to `recvmsg()`.

This PR fixes `ip monitor` running with the `all-nsid` option - When passing `all-nsid` the kernel passes the nsid as ancillary data.
However, if while `ip monitor` runs an event on the current netns is received, then no ancillary data will be sent, causing the `msg.msg_controllen` to be set to 0.

This means future calls to `recvmsg()`, which otherwise would receive the nsid as ancillary data, will instead have `MSG_CTRUNC` being set in `msg.msg_flags` (and `[nsid current]` will be printed for all eternity, which is fixable only by stopping and running `ip monitor` again)