### PR TITLE
Fix a typo in optimistic flag

### DIFF
--- a/man/man8/ip-address.8.in
+++ b/man/man8/ip-address.8.in
@@ -93,7 +93,7 @@ ip-address \- protocol address management
 
 .ti -8
 .IR CONFFLAG " := "
-.RB "[ " home " | " mngtmpaddr " | " nodad " | " optimstic " | " noprefixroute " | " autojoin " ]"
+.RB "[ " home " | " mngtmpaddr " | " nodad " | " optimistic " | " noprefixroute " | " autojoin " ]"
 
 .ti -8
 .IR LIFETIME " := [ "


### PR DESCRIPTION
Fixes a small typo in the man file for the ip command.