### PR TITLE
tc: fix no error return with large for parent id

### DIFF
--- a/tc/tc_util.c
+++ b/tc/tc_util.c
@@ -93,7 +93,7 @@ ok:
 
 int get_tc_classid(__u32 *h, const char *str)
 {
-	__u32 maj, min;
+	unsigned long maj, min;
 	char *p;
 
 	maj = TC_H_ROOT;


### PR DESCRIPTION
To fix the issue that large value for parent id is not handling properly

Signed-off-by: Zulkifli, Muhammad Husaini <muhammad.husaini.zulkifli@intel.com>
Signed-off-by: Lai Jun Ann <jun.ann.lai@intel.com>