### PR TITLE
[PATCH] misc: Fix fopen check

### DIFF
--- a/misc/ss.c
+++ b/misc/ss.c
@@ -5791,7 +5791,7 @@ int main(int argc, char *argv[])
 		}
 		if (dump_tcpdiag[0] != '-') {
 			dump_fp = fopen(dump_tcpdiag, "w");
-			if (!dump_tcpdiag) {
+			if (!dump_fp) {
 				perror("fopen dump file");
 				exit(-1);
 			}


### PR DESCRIPTION
There should be a check for the `dump_fp` file descriptor, not the `dump_tcpdiag` variable, which is guaranteed not to be NULL.