### PR TITLE
Signal if RTM_NEWROUTE is is an NLM_F_REPLACE

### DIFF
--- a/ip/iproute.c
+++ b/ip/iproute.c
@@ -793,6 +793,8 @@ int print_route(struct nlmsghdr *n, void *arg)
 	open_json_object(NULL);
 	if (n->nlmsg_type == RTM_DELROUTE)
 		print_bool(PRINT_ANY, "deleted", "Deleted ", true);
+	if (n->nlmsg_flags & NLM_F_REPLACE)
+		print_bool(PRINT_ANY, "replaced", "Replaced ", true);
 
 	if ((r->rtm_type != RTN_UNICAST || show_details > 0) &&
 	    (!filter.typemask || (filter.typemask & (1 << r->rtm_type))))


### PR DESCRIPTION
I recently came across a bug in the interaction between Bird2 and VPP with respect to IPv4 and IPv6 route propagation - context in:
- http://trubka.network.cz/pipermail/bird-users/2023-May/016946.html
- https://lists.fd.io/g/vpp-dev/topic/netlink_replace_messages/99042917

Using 'ip monitor' it does not become obvious if message type RTM_NEWROUTE is a create or a replace, the latter being revealed by the message header's flags containing NLM_F_REPLACE. Would it be OK to add this 'Replaced' similar to 'Deleted' -- and if so, would there be other message types where the REPLACE could make sense to print? I checked on 'ip addr replace' but that turned into an add, so I thought I'd check.
