### PR TITLE
bridge: mdb: add missing limits.h include

### DIFF
--- a/bridge/mdb.c
+++ b/bridge/mdb.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <limits.h>
 
 #include "libnetlink.h"
 #include "utils.h"


### PR DESCRIPTION
Adding limits.h include for USHRT_MAX and ULONG_MAX. Don't rely on it being transitively include (as it is not on musl).